### PR TITLE
Adding functionality to solve MIQPs

### DIFF
--- a/Osi/src/Osi/OsiSolverParameters.hpp
+++ b/Osi/src/Osi/OsiSolverParameters.hpp
@@ -39,8 +39,21 @@ enum OsiIntParam {
 	 supplied by the client. Requests for a vector of names return a
 	 vector sized to match the constraint system, and all entries will
 	 contain either the name specified by the client or a generated name.
+
   */
   OsiNameDiscipline,
+  /*OsiParallelThreads: Set number of threads to be used: 0 means use number of CPU cores, while number > 0 tells CPLEX to use this number of threads explicitly*/
+  OsiParallelThreads,
+  /*Set parallel mode: -1 parallel opportunistic, 0 parallel auto (solver chooses, this is default), 1 parallel deterministic*/
+  OsiParallelMode,
+  /*Determines amount of output to stdout: 0 off, 1 on*/
+  OsiOutputControl,
+  /*Determines amount of output to stdout for MIP solver: 0 only when finished, 1, display feas int sols, 2, more display, etc., to 5*/
+  OsiMIPOutputControl,
+  /*For nonlinear problem, set target solution type, 0 auto, 1 global for convex problem, 2 local (satifying first order), 3 global*/
+  OsiSolutionTarget,
+  /*Set MIP solver heuristic paramter, -1 turn off, 0 let solver decide (default), > 0 periodic freq*/
+  OsiHeurFreq,
   /*! \brief End marker.
   
     Used by OsiSolverInterface to allocate a fixed-sized array to store

--- a/Osi/src/OsiCpx/OsiCpxSolverInterface.hpp
+++ b/Osi/src/OsiCpx/OsiCpxSolverInterface.hpp
@@ -60,6 +60,8 @@ public:
      returned in the second argument. Otherwise they return false.
   */
   //@{
+  //
+    int readParametersFromFile(const char * const filename);
     // Set an integer parameter
     bool setIntParam(OsiIntParam key, int value);
     // Set an double parameter
@@ -76,6 +78,9 @@ public:
     void setMipStart(bool value) { domipstart = value; }
     // Get mipstart option value
     bool getMipStart() const { return domipstart; }
+
+    bool getSolvingMIQP(){return solvingMIQP_;}
+    void setSolvingMIQP(bool miqp){solvingMIQP_=miqp;}
   //@}
 
   //---------------------------------------------------------------------------
@@ -311,6 +316,7 @@ public:
       virtual void setObjCoeffSet(const int* indexFirst,
 				  const int* indexLast,
 				  const double* coeffList);
+      void setSeparableQuadraticObjectiveCoefficients(double* diagonalElements);
 
       using OsiSolverInterface::setColLower ;
       /** Set a single column lower bound<br>
@@ -588,6 +594,9 @@ public:
 	If objSense is non zero then -1.0 forces the code to write a
 	maximization objective and +1.0 to write a minimization one.
 	If 0.0 then solver can do what it wants */
+    virtual void writeLP(const char *filename,
+			  const char *extension = "lp",
+                          double objSense=0.0) const;
     virtual void writeMps(const char *filename,
 			  const char *extension = "mps",
                           double objSense=0.0) const;
@@ -751,12 +760,6 @@ public:
 
 protected:
   
-  /// Get LP Pointer for const methods
-  CPXLPptr getMutableLpPtr() const;
-
-  /// Get Environment Pointer for const methods
-  CPXENVptr getMutableEnvironmentPtr() const;
-
   /**@name Protected methods */
   //@{
   /// Apply a row cut. Return true if cut was applied.
@@ -781,7 +784,10 @@ private:
   
   /**@name Private methods */
   //@{
-    
+  
+  /// Get LP Pointer for const methods
+  CPXLPptr getMutableLpPtr() const;
+  
   /// The real work of a copy constructor (used by copy and assignment)
   void gutsOfCopy( const OsiCpxSolverInterface & source );
   
@@ -880,7 +886,11 @@ private:
   int             coltypesize_;
   
   /// Stores whether CPLEX' prob type is currently set to MIP
+  //Note: This parameter is general enough to subsume QMIP, no need for a separate probtypeqmip_;
   mutable bool    probtypemip_;
+
+  bool solvingMIQP_;
+  double *sepDiagQuadraticCoefficients_;
 
   /// Whether to pass a column solution to CPLEX before starting MIP solve (copymipstart)
   bool            domipstart;


### PR DESCRIPTION
I intend to have the functionality to solve MIQPs added to OsiCpx, and also to have the setting of additional CPLEX parameters enabled.

Other differences not related to the above two themes should probably be ignored, as these arise from using an older version of OsiCpx. So please feel free to be selective in the changes that are incorporated. 